### PR TITLE
modified chart css values to fit wide and narrow screen

### DIFF
--- a/src/assets/scss/views/shared/_chart.scss
+++ b/src/assets/scss/views/shared/_chart.scss
@@ -97,16 +97,16 @@
 .chart-container-statistics {
   position: relative;
   margin: auto;
-  width: 75vw;
-  height: 70vh;
-  @media (max-width: 1280px) {
-    width: 90vw;
-    height: 50vh;
-  }
+  width: calc((100vw - 260px) * 0.95);
+  height: calc((100vw - 260px) * 0.5);
   @media (max-width: 991px) {
-    width: 100vw;
-    height: 30vh;
+    width: 95vw;
+    height: calc(95vw * 0.5);
   }
+    .chartjs-render-monitor {
+      width: 100% !important;
+      height: 100% !important;
+    }
 }
 
 .chart {


### PR DESCRIPTION
resized the chart container size 
- to fill 90% of the viewport width with the navbar width subtracted (= 90% of the usefull width)
- to keep a good ratio width/height I calculated the height depending on the width

Deleted the @media (max-width: 1280px) as it works the same as above.

Modified the @media (max-width: 991px) to keep ratio size and now it's always viewable on any size.

Added .chartjs-render-monitor to 100% both width and height so it fits the container values.
